### PR TITLE
Update root selector

### DIFF
--- a/sample-app1/src/app/app.component.ts
+++ b/sample-app1/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: 'sample-app1-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/sample-app1/src/main.single-spa.ts
+++ b/sample-app1/src/main.single-spa.ts
@@ -19,7 +19,7 @@ const lifecycles = singleSpaAngular({
     singleSpaPropsSubject.next(singleSpaProps);
     return platformBrowserDynamic(getSingleSpaExtraProviders()).bootstrapModule(AppModule);
   },
-  template: '<app-root />',
+  template: '<sample-app1-root />',
   Router,
   NavigationStart,
   NgZone,

--- a/sample-app2/src/app/app.component.ts
+++ b/sample-app2/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: 'sample-app2-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/sample-app2/src/main.single-spa.ts
+++ b/sample-app2/src/main.single-spa.ts
@@ -19,7 +19,7 @@ const lifecycles = singleSpaAngular({
     singleSpaPropsSubject.next(singleSpaProps);
     return platformBrowserDynamic(getSingleSpaExtraProviders()).bootstrapModule(AppModule);
   },
-  template: '<app-root />',
+  template: '<sample-app2-root />',
   Router,
   NavigationStart,
   NgZone,

--- a/sidebar/src/app/app.component.ts
+++ b/sidebar/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: 'sidebar-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/sidebar/src/main.single-spa.ts
+++ b/sidebar/src/main.single-spa.ts
@@ -19,7 +19,7 @@ const lifecycles = singleSpaAngular({
     singleSpaPropsSubject.next(singleSpaProps);
     return platformBrowserDynamic(getSingleSpaExtraProviders()).bootstrapModule(AppModule);
   },
-  template: '<app-root />',
+  template: '<sidebar-root />',
   Router,
   NavigationStart,
   NgZone,


### PR DESCRIPTION
Each project should have been generated with the flag **_--prefix_** so that the root selector was uniquely named, preventing the single spa from replacing one project's template with another. This pr fixes this by manually updating each selector.